### PR TITLE
Add mini-coi to enable SharedArrayBuffer

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://pyscript.net/releases/2025.7.3/core.css" />
   <script type="module" src="https://pyscript.net/releases/2025.7.3/core.js"></script>
   <link rel="stylesheet" href="style.css" />
+  <script src="./mini-coi.js"></script>
   <script type="module" src="main.js"></script>
 </head>
 <body>

--- a/main.js
+++ b/main.js
@@ -127,6 +127,7 @@ window.addEventListener("DOMContentLoaded", () => {
     doc.write(`<!DOCTYPE html>
 <html lang="en">
 <head>
+  <script src="./mini-coi.js"></script>
   <link rel="stylesheet" href="https://pyscript.net/releases/2025.7.3/core.css" />
   <script type="module" src="https://pyscript.net/releases/2025.7.3/core.js"></script>
   ${cssCode}

--- a/mini-coi.js
+++ b/mini-coi.js
@@ -1,0 +1,28 @@
+/*! coi-serviceworker v0.1.7 - Guido Zuidhof and contributors, licensed under MIT */
+/*! mini-coi - Andrea Giammarchi and contributors, licensed under MIT */
+(({ document: d, navigator: { serviceWorker: s } }) => {
+  if (d) {
+    const { currentScript: c } = d;
+    s.register(c.src, { scope: c.getAttribute('scope') || '.' }).then(r => {
+      r.addEventListener('updatefound', () => location.reload());
+      if (r.active && !s.controller) location.reload();
+    });
+  }
+  else {
+    addEventListener('install', () => skipWaiting());
+    addEventListener('activate', e => e.waitUntil(clients.claim()));
+    addEventListener('fetch', e => {
+      const { request: r } = e;
+      if (r.cache === 'only-if-cached' && r.mode !== 'same-origin') return;
+      e.respondWith(fetch(r).then(r => {
+        const { body, status, statusText } = r;
+        if (!status || status > 399) return r;
+        const h = new Headers(r.headers);
+        h.set('Cross-Origin-Opener-Policy', 'same-origin');
+        h.set('Cross-Origin-Embedder-Policy', 'require-corp');
+        h.set('Cross-Origin-Resource-Policy', 'cross-origin');
+        return new Response(body, { status, statusText, headers: h });
+      }));
+    });
+  }
+})(self);


### PR DESCRIPTION
This MR adds [mini-coi](https://github.com/WebReflection/mini-coi) so that the *Worker* option won't fail if you try to access `window` or `document` from the Python code itself.